### PR TITLE
fix(playlist): Reverse track list to ensure correct sequential proces…

### DIFF
--- a/src/mod/features/utils/downloader.ts
+++ b/src/mod/features/utils/downloader.ts
@@ -134,8 +134,8 @@ export async function getPlaylistTracks(id: string): Promise<Result<string[], st
     }
 
     const trackIds = response.data.tracks.map((track: any) => track.id);
-
-    return ok(trackIds);
+    const reversedTrackIds = trackIds.reverse();
+    return ok(reversedTrackIds);
   } catch (error) {
     return err(`Failed to get playlist tracks: ${error}`);
   }


### PR DESCRIPTION
The getPlaylistTracks function now explicitly reverses the list of track IDs after fetching them from the Yandex Music API.

This adjustment is necessary for the "Transfer Tracks" feature. When the mod processes the tracks (e.g., by liking them), reversing the list ensures they are processed in the intended chronological/sequential order, preventing tracks from being liked in reverse order.