### PR TITLE
Разворот плейлиста

### DIFF
--- a/src/mod/features/ui/components/auto-liker.tsx
+++ b/src/mod/features/ui/components/auto-liker.tsx
@@ -74,7 +74,7 @@ export function AutoLiker() {
 
     console.log("[AutoLiker] userId", userId);
 
-    for (var i = 0; i < trackIds.value.length; i++) {
+    for (var i = trackIds.value.length - 1; i < 0; i--) { // последние лайкнутые треки окажутся сверху
       if (stopSignal.current) {
         setIsInProgress(false);
         return;


### PR DESCRIPTION
Теперь последние лайкнутые треки будут вверху плейлиста, как и должны